### PR TITLE
fix: post install script and await in action

### DIFF
--- a/app/action.ts
+++ b/app/action.ts
@@ -38,7 +38,7 @@ export async function postData(formData: FormData) {
     useTLS: true,
   });
 
-  pusher.trigger("my-channel", "chat-event", {
+  await pusher.trigger("my-channel", "chat-event", {
     message: `${JSON.stringify(data)}\n\n`,
   });
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.4.0",


### PR DESCRIPTION
Deploying Prisma to Vercel causes a complaint about Vercels caching, post install script addresses this 

`await` pusher trigger in server function 